### PR TITLE
use base.en-q5_1 model instead of tiny.en-q8_0 to increase transcription quality and heavily reduce hallucinations

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/transcribro/recognitionservice/MainRecognitionService.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/transcribro/recognitionservice/MainRecognitionService.kt
@@ -65,7 +65,7 @@ class MainRecognitionService : RecognitionService() {
                     override fun getWhisperContext(): WhisperContext {
                         return WhisperContext.createContextFromAsset(
                             application.assets,
-                            "models/whisper/ggml-tiny.en-q8_0.bin"
+                            "models/whisper/ggml-base.en-q5_1.bin"
                         )
                     }
                 },


### PR DESCRIPTION
The trade-off is worth it. The tiny.en model had far too many hallucinations so the increased speed was not worth it for the decreased accuracy since we only include one model now.