### PR TITLE
remove " ." to reduce hallucination that sometimes appears at the end of the transcript

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/transcribro/recognitionservice/whisper/WhisperRepository.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/transcribro/recognitionservice/whisper/WhisperRepository.kt
@@ -23,7 +23,8 @@ class WhisperRepository(
         val buffer = FloatArray(data.size) { index ->
             (data[index] / 32767.0f).coerceIn(-1f..1f)
         }
-        return whisperContext.value?.transcribeData(buffer, ((data.size / 16000f) * 1000f).toLong()) ?: ""
+        val transcript = whisperContext.value?.transcribeData(buffer, ((data.size / 16000f) * 1000f).toLong()) ?: ""
+        return transcript.removeSuffix(" .") // remove hallucination
     }
 
     suspend fun release() {


### PR DESCRIPTION
I don't think " ." at the end is ever used in any actual transcripts.