### PR TITLE
switch back to tiny.en-q5_1 model

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/transcribro/recognitionservice/MainRecognitionService.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/transcribro/recognitionservice/MainRecognitionService.kt
@@ -67,7 +67,7 @@ class MainRecognitionService : RecognitionService() {
                     override fun getWhisperContext(): WhisperContext {
                         return WhisperContext.createContextFromAsset(
                             application.assets,
-                            "models/whisper/ggml-base.en-q5_1.bin"
+                            "models/whisper/ggml-model-whisper-tiny.en-q5_1.bin"
                         )
                     }
                 },


### PR DESCRIPTION
The tiny.en-q5_1 model is sufficient in most cases and faster. The switch to the base.en-q5_1 model was made because it was thought that it solved hallucinations, but the hallucinations were another problem so the tiny.en-q5_1 model actually works great.