### PR TITLE
Keyboard: Adapt output transcript capitalization and punctuation to the surrounding and selected text

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/transcribro/ui/voiceinput/VoiceInput.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/transcribro/ui/voiceinput/VoiceInput.kt
@@ -298,6 +298,7 @@ class VoiceInput : InputMethodService() {
                                                                         2,
                                                                         0
                                                                     ) == "") || (ic.getTextBeforeCursor(1, 0) == "\n")
+                                                                    || (ic.getTextBeforeCursor(1, 0) == " ")
                                                                 ) {
                                                                     transcription.removePrefix(" ")
                                                                 } else {


### PR DESCRIPTION
Here is a simple example of this feature:

Selecting a word and transcribing while it is selected willl result in the new transcript starting with the capitalization of the word you selected and ending with the punctuation of the selected word as well.

For example:

"I see berries over there."

The word berries can be selected and a transcription can be done saying for example "peanuts", and it will replace berries with peanuts without any capitalization or punctuation. If the text was originally "I see humongous berries, with frosting on top.", then by selecting berries and saying "peanuts", the output will keep the comma from the original text. So the result will be "I see humongous peanuts, with frosting on top.".

You can also select and/or say multiple words and similar rules will apply. This is an awesome improvement for editing the transcript without having to switch back to other keyboards.